### PR TITLE
Support logicalTypes type overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,57 @@ const schema = JSON.parse(schemaText) as RecordType;
 console.log(avroToTypeScript(schema as RecordType));
 ```
 
+## Override logicalTypes
+
+Tools like [avsc](https://github.com/mtth/avsc) allow you to [override the serialization/deserialization of LogicalTypes](https://github.com/mtth/avsc/wiki/Advanced-usage#logical-types),
+ say from numbers to native JS Date objects, in this case we want to generate the typescript type as 'Date', not 'number'.
+ Therefore, you can pass in a map 'logicalTypes' to the options to override the outputted TS type for the schema logicalType.
+ 
+For example:
+
+```typescript
+const schema: Schema = {
+    type: "record",
+    name: "logicalOverrides",
+    fields: [
+        {
+            name: "eventDate",
+            type: {
+                type: "int",
+                logicalType: "date",
+            },
+        },
+        {
+            name: "startTime",
+            type: {
+                type: "int",
+                logicalType: "timestamp-millis",
+            },
+        },
+        {
+            name: "displayTime",
+            type: {
+                type: "string",
+                logicalType: "iso-datetime",
+            },
+        },
+    ],
+};
+const actual = avroToTypeScript(schema, {
+logicalTypes: {
+    date: 'Date',
+    'timestamp-millis': 'Date',
+}
+});
+
+// this will output
+export interface logicalOverrides {
+    eventDate: Date;
+    startTime: Date;
+    displayTime: string;
+}
+```
+
 ## Features
 
 Most Avro features are supported, including:

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,9 @@
 /**** Contains the Interfaces and Type Guards for Avro schema */
 
 export type Schema = RecordType | EnumType;
+export interface ConversionOptions {
+    logicalTypes?: { [type: string]: string };
+}
 
 export type Type = NameOrType | NameOrType[];
 export type NameOrType = TypeNames | RecordType | ArrayType | NamedType | LogicalType;

--- a/test/__snapshots__/avtsc.test.ts.snap
+++ b/test/__snapshots__/avtsc.test.ts.snap
@@ -22,6 +22,15 @@ export interface ExampleType {
 "
 `;
 
+exports[`avroToTypeScript it should support overriding logical types 1`] = `
+"export interface logicalOverrides {
+	eventDate: Date;
+	startTime: Date;
+	displayTime: string;
+}
+"
+`;
+
 exports[`enumToTypesScript it should generate an enum 1`] = `
 "export enum CompanySize { SMALL, MEDIUM, LARGE };
 "

--- a/test/avtsc.test.ts
+++ b/test/avtsc.test.ts
@@ -25,6 +25,46 @@ describe("avroToTypeScript", () => {
         };
         expect(avroToTypeScript(schema)).not.toEqual(expect.stringContaining("UNKNOWN"));
     });
+
+    test("it should support overriding logical types", () => {
+        const schema: Schema = {
+            type: "record",
+            name: "logicalOverrides",
+            fields: [
+                {
+                    name: "eventDate",
+                    type: {
+                        type: "int",
+                        logicalType: "date",
+                    },
+                },
+                {
+                    name: "startTime",
+                    type: {
+                        type: "int",
+                        logicalType: "timestamp-millis",
+                    },
+                },
+                {
+                    name: "displayTime",
+                    type: {
+                        type: "string",
+                        logicalType: "iso-datetime",
+                    },
+                },
+            ],
+        };
+        const actual = avroToTypeScript(schema, {
+            logicalTypes: {
+                date: 'Date',
+                'timestamp-millis': 'Date',
+            }
+        });
+        expect(actual).toMatchSnapshot();
+        expect(actual).not.toEqual(expect.stringContaining("eventDate: number"));
+        expect(actual).not.toEqual(expect.stringContaining("startTime: number"));
+        expect(actual).toEqual(expect.stringContaining("displayTime: string"));
+    });
 });
 
 describe("enumToTypesScript", () => {


### PR DESCRIPTION
* Add an opts arg to the avroToTypeScript function
* When converting, if type is logicalType and that logicalType exists in opts.logicalTypes, then use the override value set there
* Add tests and docs for the overrides case